### PR TITLE
MVP zombie packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       {
         "command": "flow-state.helloWorld",
         "title": "Flow-State: Hello World"
+      },
+      {
+        "command": "flow-state.checkZombiePackages",
+        "title": "Flow-State: Check Zombie Packages"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { checkZombiePackages } from './zombiePackages';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -19,8 +20,14 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage('Hello World from Flow-State!');
 	});
 
-	context.subscriptions.push(disposable);
+	const outputChannel = vscode.window.createOutputChannel('Flow-State');
+
+	const zombieDisposable = vscode.commands.registerCommand('flow-state.checkZombiePackages', () => {
+		checkZombiePackages(outputChannel);
+	});
+
+	context.subscriptions.push(disposable, outputChannel, zombieDisposable);
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/zombiePackages.ts
+++ b/src/zombiePackages.ts
@@ -1,0 +1,189 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+/**
+ * Recursively find all files with the given extensions under a directory,
+ * skipping node_modules and .git.
+ */
+function findSourceFiles(dir: string): string[] {
+    const results: string[] = [];
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return results;
+    }
+    for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === '.git') {
+            continue;
+        }
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            results.push(...findSourceFiles(fullPath));
+        } else if (SOURCE_EXTENSIONS.includes(path.extname(entry.name))) {
+            results.push(fullPath);
+        }
+    }
+    return results;
+}
+
+/**
+ * Collect all import/require strings from a source file using simple regex.
+ * Handles:
+ *   import ... from 'pkg'
+ *   import('pkg')
+ *   require('pkg')
+ */
+function extractImports(filePath: string): Set<string> {
+    const imports = new Set<string>();
+    let content: string;
+    try {
+        content = fs.readFileSync(filePath, 'utf8');
+    } catch {
+        return imports;
+    }
+
+    const patterns = [
+        /from\s+['"]([^'"]+)['"]/g,
+        /import\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+        /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    ];
+
+    for (const pattern of patterns) {
+        let match: RegExpExecArray | null;
+        while ((match = pattern.exec(content)) !== null) {
+            imports.add(match[1]);
+        }
+    }
+    return imports;
+}
+
+/**
+ * Given an import specifier like 'lodash/merge' or '@types/node', return the
+ * top-level package name ('lodash' or '@types/node').
+ */
+function packageNameFromSpecifier(specifier: string): string {
+    if (specifier.startsWith('@')) {
+        // scoped: @scope/name[/...]
+        const parts = specifier.split('/');
+        return parts.slice(0, 2).join('/');
+    }
+    return specifier.split('/')[0];
+}
+
+/**
+ * Finds all package.json files under a directory, skipping node_modules and .git.
+ */
+function findPackageJsonFiles(dir: string): string[] {
+    const results: string[] = [];
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return results;
+    }
+
+    for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === '.git') {
+            continue;
+        }
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            results.push(...findPackageJsonFiles(fullPath));
+        } else if (entry.name === 'package.json') {
+            results.push(fullPath);
+        }
+    }
+    return results;
+}
+
+interface ZombiePackagesResult {
+    packageJsonPath: string;
+    zombies: string[];
+}
+
+/**
+ * Find zombie (unused) packages in a single package.json.
+ * Source files are scanned from the same directory as the package.json.
+ */
+function findZombiesInPackageJson(packageJsonPath: string): ZombiePackagesResult {
+    const dir = path.dirname(packageJsonPath);
+    let json: Record<string, unknown>;
+    try {
+        json = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    } catch {
+        return { packageJsonPath, zombies: [] };
+    }
+
+    const deps = Object.keys({
+        ...(json.dependencies as Record<string, string> | undefined ?? {}),
+        ...(json.devDependencies as Record<string, string> | undefined ?? {}),
+    });
+
+    if (deps.length === 0) {
+        return { packageJsonPath, zombies: [] };
+    }
+
+    // Collect all imports across source files
+    const allImportedPackages = new Set<string>();
+    for (const file of findSourceFiles(dir)) {
+        for (const specifier of extractImports(file)) {
+            allImportedPackages.add(packageNameFromSpecifier(specifier));
+        }
+    }
+
+    const zombies = deps.filter(dep => !allImportedPackages.has(dep));
+
+    return { packageJsonPath, zombies };
+}
+
+/**
+ * Main entry point called from the extension command for checking zombie packages.
+ */
+export async function checkZombiePackages(outputChannel: vscode.OutputChannel): Promise<void> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+
+    outputChannel.clear();
+    outputChannel.show(true);
+    outputChannel.appendLine('=== Flow-State: Zombie Package Check ===');
+    outputChannel.appendLine('');
+
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        outputChannel.appendLine('Error: No workspace folder found.');
+        return;
+    }
+
+    let totalZombies = 0;
+
+    for (const folder of workspaceFolders) {
+        const rootPath = folder.uri.fsPath;
+        outputChannel.appendLine(`Scanning: ${rootPath}`);
+
+        const packageJsonFiles = findPackageJsonFiles(rootPath);
+
+        if (packageJsonFiles.length === 0) {
+            outputChannel.appendLine('No package.json found.\n');
+            continue;
+        }
+
+        for (const pkgPath of packageJsonFiles) {
+            const { zombies } = findZombiesInPackageJson(pkgPath);
+            const relPath = path.relative(rootPath, pkgPath);
+            if (zombies.length === 0) {
+                outputChannel.appendLine(`${relPath} — no zombie packages`);
+            } else {
+                outputChannel.appendLine(`${relPath} — ${zombies.length} zombie package(s):`);
+                for (const z of zombies) {
+                    outputChannel.appendLine(`  - ${z}`);
+                }
+                totalZombies += zombies.length;
+            }
+        }
+        outputChannel.appendLine('');
+    }
+
+    outputChannel.appendLine(`Done. Total zombie packages found: ${totalZombies}`);
+}


### PR DESCRIPTION
Checks all the package.json files from the root directory recursively and the imports, then checks if there are packages that are not imported -> these are zombie packages and logged to the output of the extension.

Command: `flow-state.checkZombiePackages`

Example of output:
```bash
=== Flow-State: Zombie Package Check ===

Scanning: /Users/jimmy/dev/making-nn-next
backend/wso2/package.json — 1 zombie package(s):
    - serverless
frontend/.next/package.json — no zombie packages
frontend/.next/types/package.json — no zombie packages
package.json — 70 zombie package(s):
    - @azure/msal-node
    - @emotion/styled
    - @mdx-js/loader
    - @mdx-js/react
    - @microsoft/microsoft-graph-client
    - @mui/base
    - @next/mdx
    - @types/hast
    - @types/mdx
    - @types/mime-types
    - @types/unist
    - @types/valid-url
    - apollo-link
    - gray-matter
    - next-mdx-remote
    - node-fetch
    - react-cookie
    - react-markdown
    - rehype-parse
    - rehype-sanitize
    - rehype-stringify
    - remark
    - remark-extract-frontmatter
    - source-map-support
    - typescript
    - unist-util-find
    - uuid
    - yaml
    - @aws-amplify/adapter-nextjs
    - @aws-amplify/backend
    - @aws-sdk/protocol-http
    - @aws-sdk/signature-v4
    - @babel/preset-env
    - @babel/preset-typescript
    - @changesets/cli
    - @graphql-codegen/add
    - @graphql-codegen/cli
    - @graphql-codegen/import-types-preset
    - @graphql-codegen/typescript
    - @graphql-codegen/typescript-operations
    - @graphql-codegen/typescript-react-apollo
    - @microsoft/microsoft-graph-types
    - @svgr/webpack
    - @swc/jest
    - @types/aws-lambda
    - @types/jest
    - @types/json-to-pretty-yaml
    - @types/node
    - @types/react
    - @types/react-dom
    - @types/uuid
    - aws-cdk
    - babel-jest
    - esbuild
    - eslint
    - eslint-config-airbnb-typescript
    - eslint-config-next
    - eslint-config-prettier
    - eslint-plugin-import
    - eslint-plugin-jsx-a11y
    - eslint-plugin-prettier
    - eslint-plugin-react
    - eslint-plugin-react-hooks
    - jest
    - jest-snapshot-serializer-raw
    - prettier
    - svgo
    - ts-jest
    - ts-node
    - tsx

Done. Total zombie packages found: 71

```